### PR TITLE
Added abstract, generic base class implementation for IRouteMetadataProvider

### DIFF
--- a/src/Nancy.Demo.Hosting.Aspnet/DefaultRouteMetadataProvider.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/DefaultRouteMetadataProvider.cs
@@ -1,23 +1,17 @@
 ﻿namespace Nancy.Demo.Hosting.Aspnet
 {
-    using System;
     using System.Collections.Generic;
     using Nancy.Routing;
 
-    public class DefaultRouteMetadataProvider : IRouteMetadataProvider
+    public class DefaultRouteMetadataProvider : RouteMetadataProvider<MyRouteMetadata>
     {
-        public Type MetadataType
-        {
-            get { return typeof(MyRouteMetadata); }
-        }
-
         // Returns object so you can have you own application-specific
         // metadata for your routes.
-        public object GetMetadata(INancyModule module, RouteDescription routeDescription)
+        protected override MyRouteMetadata GetRouteMetadata(INancyModule module, RouteDescription routeDescription)
         {
             // Return the same metadata for all routes in this sample
             // You would use the Path & Method of the routeDescription
-            // to determin route specific metadata
+            // to determine route specific metadata
             return new MyRouteMetadata(routeDescription.Method, routeDescription.Path);
         }
     }

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -1674,15 +1674,47 @@ namespace Nancy.Testing
                 return this;
             }
 
+            /// <summary>
+            /// Configures the bootstrapper to create an <see cref="IRouteSegmentConstraint"/> instance of the specified type.
+            /// </summary>
+            /// <typeparam name="T">The type of the <see cref="IRouteSegmentConstraint"/> that the bootstrapper should use.</typeparam>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
             public ConfigurableBootstrapperConfigurator RouteSegmentConstraint<T>() where T : IRouteSegmentConstraint
             {
                 this.bootstrapper.configuration.RouteSegmentConstraints = new List<Type> { typeof(T) };
                 return this;
             }
 
+            /// <summary>
+            /// Configures the bootstrapper to use specific route segment constraints.
+            /// </summary>
+            /// <param name="types">Collection of route segment constraint types</param>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
             public ConfigurableBootstrapperConfigurator RouteSegmentConstraints(params Type[] types)
             {
                 this.bootstrapper.configuration.RouteSegmentConstraints = new List<Type>(types);
+                return this;
+            }
+
+            /// <summary>
+            /// Configures the bootstrapper to create an <see cref="IRouteMetadataProvider"/> instance of the specified type.
+            /// </summary>
+            /// <typeparam name="T">The type of the <see cref="IRouteMetadataProvider"/> that the bootstrapper should use.</typeparam>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteMetadataProvider<T>() where T : IRouteMetadataProvider
+            {
+                this.bootstrapper.configuration.RouteMetadataProviders = new List<Type> { typeof(T) };
+                return this;
+            }
+
+            /// <summary>
+            /// Configures the bootstrapper to use specific route metadata providers.
+            /// </summary>
+            /// <param name="types">Collection of route metadata provider types</param>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteMetadataProviders(params Type[] types)
+            {
+                this.bootstrapper.configuration.RouteMetadataProviders = new List<Type>(types);
                 return this;
             }
 

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Routing\OptionsRoute.cs" />
     <Compile Include="Routing\RouteCacheExtensions.cs" />
     <Compile Include="Routing\RouteMetadata.cs" />
+    <Compile Include="Routing\RouteMetadataProvider.cs" />
     <Compile Include="Routing\Trie\IRouteResolverTrie.cs" />
     <Compile Include="Routing\Trie\ITrieNodeFactory.cs" />
     <Compile Include="Routing\Trie\MatchResult.cs" />

--- a/src/Nancy/Routing/RouteMetadataProvider.cs
+++ b/src/Nancy/Routing/RouteMetadataProvider.cs
@@ -1,0 +1,29 @@
+namespace Nancy.Routing
+{
+    using System;
+
+    /// <summary>
+    /// Defines the functionality for retrieving metadata for routes.
+    /// </summary>
+    /// <typeparam name="TMetadata">The metadata type.</typeparam>
+    public abstract class RouteMetadataProvider<TMetadata> : IRouteMetadataProvider
+    {
+        public Type MetadataType
+        {
+            get { return typeof(TMetadata); }
+        }
+
+        public object GetMetadata(INancyModule module, RouteDescription routeDescription)
+        {
+            return this.GetRouteMetadata(module, routeDescription);
+        }
+
+        /// <summary>
+        /// Gets the metadata for the provided route.
+        /// </summary>
+        /// <param name="module">The <see cref="INancyModule"/> instance that the route is declared in.</param>
+        /// <param name="routeDescription">A <see cref="RouteDescription"/> for the route.</param>
+        /// <returns>An instance of <see cref="TMetadata"/>.</returns>
+        protected abstract TMetadata GetRouteMetadata(INancyModule module, RouteDescription routeDescription);
+    }
+}


### PR DESCRIPTION
I also fixed a failing test (`ConfigurableBootstrapper` convention) :smile:
